### PR TITLE
Compact Invalidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 /.build
 /.swiftpm
+/.idea

--- a/Sources/PrintKit/Constants.swift
+++ b/Sources/PrintKit/Constants.swift
@@ -7,7 +7,7 @@
 //
 
 public enum PrintKitConstants {
-    public static let version = "0.0.2"
+    public static let version = "0.0.3"
     public static let configFile = "contents.json"
     public static let timeStampsFile = ".contents-ts.json"
     public static let rootFolderEnvironmentVariable = "PRINTROOT"

--- a/Sources/PrintKit/Foundation+Extensions.swift
+++ b/Sources/PrintKit/Foundation+Extensions.swift
@@ -12,7 +12,7 @@ import Foundation
 extension Encodable {
     public func endcoded() throws -> Data {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         return try encoder.encode(self)
     }
 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -94,7 +94,8 @@ You can use the [JSON Schema Validator](https://www.jsonschemavalidator.net) to 
                                 }
                             ]
                         }
-                    }
+                    },
+                    "compactInvalidation": { "type": "boolean" }
                 },
                 "required": ["folder", "files"]
            }   
@@ -123,6 +124,7 @@ Each element in the `contents` array should contain the following:
 | ---------- | ------------- |
 | `folder` | The path in the S3 bucket that will contain the files specified by the `files` property. |
 | `files`  | An array of local file paths to be uploaded in `folder`. Each element in this array can be either a string containing the local file path or an array of two strings where the first element is the local file path and the second is the remote file name. The local file paths are relative to the `contents.json` folder. |
+| `compactInvalidation` | When set to `true`, invalidates everything under this folder rather than invalidating individual files when two or more files have changed. The default value is `false` if the key is omitted. |
 
 ### Sample `contents.json`
 


### PR DESCRIPTION
You can now use the automatic generation of compact CloudFront invalidations for specified folders.

This helps reduce the costs of CloudFront by reducing the number of keys invalidated through the use of globals.

This resolves issue #9.

