### PR TITLE
Enable file purging by comparing 'contents.json' files

### DIFF
--- a/Sources/PrintKit/Constants.swift
+++ b/Sources/PrintKit/Constants.swift
@@ -7,8 +7,9 @@
 //
 
 public enum PrintKitConstants {
-    public static let version = "0.0.3"
+    public static let version = "0.0.4"
     public static let configFile = "contents.json"
+    public static let oldConfigFile = "contents.old.json"
     public static let timeStampsFile = ".contents-ts.json"
     public static let rootFolderEnvironmentVariable = "PRINTROOT"
 

--- a/Sources/PrintKit/Foundation+Extensions.swift
+++ b/Sources/PrintKit/Foundation+Extensions.swift
@@ -71,3 +71,9 @@ extension String {
         return path
     }
 }
+
+extension Int {
+    func plural(_ word: String) -> String {
+        self == 1 ? word : "\(word)s"
+    }
+}

--- a/Tests/PrintKitTests/ContentConfigTests.swift
+++ b/Tests/PrintKitTests/ContentConfigTests.swift
@@ -135,6 +135,52 @@ final class ContentConfigTests: XCTestCase {
         XCTAssertEqual(resultKeys, expectedKeys)
     }
 
+    func testBuildCloudFrontKeys() throws {
+        let data = Data("""
+            {
+              "region": "someRegion",
+              "bucket": "someBucket",
+              "cloudFront": "someCloudFront",
+              "originPathFolder": "someOriginPathFolder",
+              "contents": [
+                {
+                    "folder": "someFolderOne/",
+                    "prune": true,
+                    "files": [
+                        "foo",
+                        "bar"
+                    ]
+                },
+                {
+                    "folder": "someFolderTwo/with/a/path",
+                    "files": [
+                        "file1",
+                    ]
+                }
+              ]
+            }
+            """.utf8)
+        var config: ContentConfiguration = try data.decoded()
+        config.isLatestConfig = false
+
+        let expectedPruneKeys = [
+            "/someFolderOne/foo",
+            "/someFolderOne/bar"
+        ]
+
+        let expectedAllKeys = [
+            "/someFolderOne/foo",
+            "/someFolderOne/bar",
+            "/someFolderTwo/with/a/path/file1"
+        ]
+
+        let resultPruneKeys = config.buildCloudFrontKeys()
+        XCTAssertEqual(resultPruneKeys, expectedPruneKeys)
+
+        config.isLatestConfig = true
+        let resultAllKeys = config.buildCloudFrontKeys()
+        XCTAssertEqual(resultAllKeys, expectedAllKeys)
+    }
 
     func testVariableExpanded() throws {
         let someBAR = "BAR"

--- a/Tests/PrintKitTests/ExtensionTests.swift
+++ b/Tests/PrintKitTests/ExtensionTests.swift
@@ -37,4 +37,11 @@ final class ExtensionTests: XCTestCase {
         let someFixedContent = "test content"
         XCTAssertEqual(someFixedContent.sha256, "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72")
     }
+
+    func testPlural() {
+        XCTAssertEqual("file",  1.plural("file"))
+        XCTAssertEqual("files", 0.plural("file"))
+        XCTAssertEqual("files", 2.plural("file"))
+    }
+
 }

--- a/Tests/PrintKitTests/S3CloudFrontDeployerTests.swift
+++ b/Tests/PrintKitTests/S3CloudFrontDeployerTests.swift
@@ -46,7 +46,7 @@ final class DeployerTests: XCTestCase {
                 let future = publisher.run()
                 do {
                     let result = try future.wait()
-                    XCTAssertGreaterThanOrEqual(result, 0)
+                    XCTAssertGreaterThanOrEqual(result.uploaded, 0)
                 } catch let error {
                     dump(error)
                     print("threw error \"\(error)\"")


### PR DESCRIPTION
Adds support for file purging. You must copy your  `contents.json` file to `contents.old.json` before adding or removing files in `contents.json` to be deployed. You must annotate each folder with `"prune": true` in the 'contents.old.json' file to enable the pruning of files in that folder. The logic compares the 'contents.json' files to determine which files need to be purged. The old file is deleted once the pruning is performed.

This works best when your `contents.json` file is auto-generated and can make the current file the old one before writing the current one.

Resolves issue #8.